### PR TITLE
Fix catkin build issues

### DIFF
--- a/open3d_slam/include/open3d_slam/Submap.hpp
+++ b/open3d_slam/include/open3d_slam/Submap.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <open3d/geometry/PointCloud.h>
-#include <ros/time.h>
 #include <Eigen/Dense>
 #include <mutex>
 #include "open3d_slam/Parameters.hpp"

--- a/open3d_slam/include/open3d_slam/SubmapCollection.hpp
+++ b/open3d_slam/include/open3d_slam/SubmapCollection.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <open3d/geometry/PointCloud.h>
-#include <ros/time.h>
 #include <Eigen/Dense>
 #include <mutex>
 #include "open3d_slam/Parameters.hpp"

--- a/open3d_slam/include/open3d_slam/time.hpp
+++ b/open3d_slam/include/open3d_slam/time.hpp
@@ -12,7 +12,6 @@
 #include <ostream>
 #include <ratio>
 #include "open3d_slam/typedefs.hpp"
-#include <ros/time.h>
 
 namespace o3d_slam {
 
@@ -76,10 +75,6 @@ int64 toUniversal(Time time);
 std::ostream& operator<<(std::ostream& os, Time time);
 
 std::string toString(const Time &time);
-
-ros::Time toRos(Time time);
-
-Time fromRos(const ::ros::Time& time);
 
 void updateFirstMeasurementTime(const Time &t);
 double toSecondsSinceFirstMeasurement(const Time &t);

--- a/open3d_slam/src/Mesher.cpp
+++ b/open3d_slam/src/Mesher.cpp
@@ -11,7 +11,6 @@
 #include "open3d_slam/math.hpp"
 
 #include <open3d/io/TriangleMeshIO.h>
-#include <ros/package.h>
 
 namespace o3d_slam {
 

--- a/open3d_slam/src/Odometry.cpp
+++ b/open3d_slam/src/Odometry.cpp
@@ -4,12 +4,13 @@
  *  Created on: Oct 15, 2021
  *      Author: jelavice
  */
-
 #include "open3d_slam/Odometry.hpp"
 #include "open3d_slam/frames.hpp"
 #include "open3d_slam/helpers.hpp"
 #include "open3d_slam/time.hpp"
 #include "open3d_slam/output.hpp"
+
+#include <iostream>
 
 namespace o3d_slam {
 

--- a/open3d_slam/src/Submap.cpp
+++ b/open3d_slam/src/Submap.cpp
@@ -11,6 +11,7 @@
 #include "open3d_slam/magic.hpp"
 
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 #include <utility>
 #include <thread>

--- a/open3d_slam/src/TransformInterpolationBuffer.cpp
+++ b/open3d_slam/src/TransformInterpolationBuffer.cpp
@@ -4,10 +4,11 @@
  *  Created on: Nov 9, 2021
  *      Author: jelavice
  */
-
 #include "open3d_slam/TransformInterpolationBuffer.hpp"
 #include "open3d_slam/time.hpp"
 #include "open3d_slam/assert.hpp"
+
+#include <iostream>
 
 namespace o3d_slam {
 

--- a/open3d_slam/src/time.cpp
+++ b/open3d_slam/src/time.cpp
@@ -121,27 +121,4 @@ std::string toString(const Time &time) {
 	return std::to_string(toUniversal(time));
 }
 
-ros::Time toRos(Time time) {
-	int64_t uts_timestamp = toUniversal(time);
-	int64_t ns_since_unix_epoch = (uts_timestamp - kUtsEpochOffsetFromUnixEpochInSeconds * 10000000ll) * 100ll;
-	::ros::Time ros_time;
-	if (ns_since_unix_epoch < 0) {
-		std::cerr << "ERROR: nanoseconds since unix epoch is: " << ns_since_unix_epoch
-				<< " which is impossible!!!! \n";
-		std::cerr << "       ROS time will throw you an exception fo sho!!!! \n";
-		std::cerr << "       Are you playing the rosbag with --clock??? \n";
-		std::cerr << "       If yes, did you set use_sim_time to true ??? \n";
-		std::cout << "Universal time: " << uts_timestamp << std::endl;
-	}
-	ros_time.fromNSec(ns_since_unix_epoch);
-	return ros_time;
-}
-
-Time fromRos(const ::ros::Time &time) {
-	// The epoch of the ICU Universal Time Scale is "0001-01-01 00:00:00.0 +0000",
-	// exactly 719162 days before the Unix epoch.
-	return fromUniversal(
-			(time.sec + kUtsEpochOffsetFromUnixEpochInSeconds) * 10000000ll + (time.nsec + 50) / 100); // + 50 to get the rounding correct.
-}
-
 } /* namespace o3d_slam */

--- a/open3d_slam_ros/include/open3d_slam_ros/helpers_ros.hpp
+++ b/open3d_slam_ros/include/open3d_slam_ros/helpers_ros.hpp
@@ -16,6 +16,8 @@
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/buffer.h>
 #include <visualization_msgs/MarkerArray.h>
+#include <ros/time.h>
+#include "open3d_slam/time.hpp"
 
 
 namespace o3d_slam {
@@ -40,5 +42,9 @@ void publishTfTransform(const Eigen::Matrix4d &Mat, const ros::Time &time, const
 		const std::string &childFrame, tf2_ros::TransformBroadcaster *broadcaster);
 bool lookupTransform(const std::string &target_frame, const std::string &source_frame, const ros::Time &time,const tf2_ros::Buffer &tfBuffer,
 		Eigen::Isometry3d *transform);
+
+ros::Time toRos(Time time);
+
+Time fromRos(const ::ros::Time& time);
 
 } /* namespace o3d_slam */

--- a/open3d_slam_ros/src/helpers_ros.cpp
+++ b/open3d_slam_ros/src/helpers_ros.cpp
@@ -163,4 +163,28 @@ void drawAxes(const Eigen::Vector3d &p, const Eigen::Quaterniond &q, double scal
 	tf::quaternionEigenToMsg(q, marker->pose.orientation);
 }
 
+
+ros::Time toRos(Time time) {
+	int64_t uts_timestamp = toUniversal(time);
+	int64_t ns_since_unix_epoch = (uts_timestamp - kUtsEpochOffsetFromUnixEpochInSeconds * 10000000ll) * 100ll;
+	::ros::Time ros_time;
+	if (ns_since_unix_epoch < 0) {
+		std::cerr << "ERROR: nanoseconds since unix epoch is: " << ns_since_unix_epoch
+				<< " which is impossible!!!! \n";
+		std::cerr << "       ROS time will throw you an exception fo sho!!!! \n";
+		std::cerr << "       Are you playing the rosbag with --clock??? \n";
+		std::cerr << "       If yes, did you set use_sim_time to true ??? \n";
+		std::cout << "Universal time: " << uts_timestamp << std::endl;
+	}
+	ros_time.fromNSec(ns_since_unix_epoch);
+	return ros_time;
+}
+
+Time fromRos(const ::ros::Time &time) {
+	// The epoch of the ICU Universal Time Scale is "0001-01-01 00:00:00.0 +0000",
+	// exactly 719162 days before the Unix epoch.
+	return fromUniversal(
+			(time.sec + kUtsEpochOffsetFromUnixEpochInSeconds) * 10000000ll + (time.nsec + 50) / 100); // + 50 to get the rounding correct.
+}
+
 } /* namespace o3d_slam */


### PR DESCRIPTION
These were issues remaining from the refactor that split ROS dependencies from non-ROS dependencies. WIthout doing catkin clean and building the workspace again, these issues were obscured.

Now `catkin clean -y` followed by `catkin build open3d_slam_ros` works