### PR TITLE
Map intialization

### DIFF
--- a/open3d_slam/include/open3d_slam/Odometry.hpp
+++ b/open3d_slam/include/open3d_slam/Odometry.hpp
@@ -29,7 +29,7 @@ public:
 	void setParameters (const OdometryParameters &p);
 	const TransformInterpolationBuffer &getBuffer() const;
 	bool hasProcessedMeasurements() const;
-	void setInitialTransform(const Eigen::Matrix4d initialTransform);
+	void setInitialTransform(const Eigen::Matrix4d &initialTransform);
 
 private:
 	TransformInterpolationBuffer odomToRangeSensorBuffer_;

--- a/open3d_slam/include/open3d_slam/Odometry.hpp
+++ b/open3d_slam/include/open3d_slam/Odometry.hpp
@@ -28,9 +28,10 @@ public:
 	const open3d::geometry::PointCloud &getPreProcessedCloud() const;
 	void setParameters (const OdometryParameters &p);
 	const TransformInterpolationBuffer &getBuffer() const;
-	bool  hasProcessedMeasurements() const;
-private:
+	bool hasProcessedMeasurements() const;
+	void setInitialTransform(Eigen::Matrix4d initial_transform);
 
+private:
 	TransformInterpolationBuffer odomToRangeSensorBuffer_;
 	open3d::geometry::PointCloud cloudPrev_;
 	Transform odomToRangeSensorCumulative_ = Transform::Identity();
@@ -39,6 +40,8 @@ private:
 	open3d::pipelines::registration::ICPConvergenceCriteria icpConvergenceCriteria_;
 	std::shared_ptr<CroppingVolume> cropper_;
 	Time lastMeasurementTimestamp_;
+	Eigen::Matrix4d icpTransform_ = Eigen::Matrix4d::Identity();
+	bool resetIcpTransform_ = false;
 };
 
 } // namespace o3d_slam

--- a/open3d_slam/include/open3d_slam/Odometry.hpp
+++ b/open3d_slam/include/open3d_slam/Odometry.hpp
@@ -29,7 +29,7 @@ public:
 	void setParameters (const OdometryParameters &p);
 	const TransformInterpolationBuffer &getBuffer() const;
 	bool hasProcessedMeasurements() const;
-	void setInitialTransform(Eigen::Matrix4d initial_transform);
+	void setInitialTransform(const Eigen::Matrix4d initialTransform);
 
 private:
 	TransformInterpolationBuffer odomToRangeSensorBuffer_;

--- a/open3d_slam/include/open3d_slam/SlamWrapper.hpp
+++ b/open3d_slam/include/open3d_slam/SlamWrapper.hpp
@@ -64,8 +64,8 @@ public:
 	void setDirectoryPath(const std::string &path);
 	void setMapSavingDirectoryPath(const std::string &path);
 	void setParameterFilePath(const std::string &path);
-	void setInitialMap(PointCloud &initial_map);
-	void setInitialTransform(Eigen::Matrix4d initial_transform);
+	void setInitialMap(const PointCloud &initialMap);
+	void setInitialTransform(const Eigen::Matrix4d initialTransform);
 
 private:
 

--- a/open3d_slam/include/open3d_slam/SlamWrapper.hpp
+++ b/open3d_slam/include/open3d_slam/SlamWrapper.hpp
@@ -64,7 +64,8 @@ public:
 	void setDirectoryPath(const std::string &path);
 	void setMapSavingDirectoryPath(const std::string &path);
 	void setParameterFilePath(const std::string &path);
-
+	void setInitialMap(PointCloud &initial_map);
+	void setInitialTransform(Eigen::Matrix4d initial_transform);
 
 private:
 

--- a/open3d_slam/src/Odometry.cpp
+++ b/open3d_slam/src/Odometry.cpp
@@ -102,7 +102,7 @@ void LidarOdometry::setParameters(const OdometryParameters &p) {
 }
 
 
-void LidarOdometry::setInitialTransform(const Eigen::Matrix4d initialTransform) {
+void LidarOdometry::setInitialTransform(const Eigen::Matrix4d &initialTransform) {
 	icpTransform_ = initialTransform;
 	resetIcpTransform_ = true;
 }

--- a/open3d_slam/src/Odometry.cpp
+++ b/open3d_slam/src/Odometry.cpp
@@ -102,8 +102,8 @@ void LidarOdometry::setParameters(const OdometryParameters &p) {
 }
 
 
-void LidarOdometry::setInitialTransform(Eigen::Matrix4d initial_transform) {
-	icpTransform_ = initial_transform;
+void LidarOdometry::setInitialTransform(const Eigen::Matrix4d initialTransform) {
+	icpTransform_ = initialTransform;
 	resetIcpTransform_ = true;
 }
 

--- a/open3d_slam/src/Odometry.cpp
+++ b/open3d_slam/src/Odometry.cpp
@@ -41,15 +41,22 @@ bool LidarOdometry::addRangeScan(const open3d::geometry::PointCloud &cloud, cons
 		o3d_slam::estimateNormals(params_.scanMatcher_.kNNnormalEstimation_, downSampledCloud.get());
 		downSampledCloud->NormalizeNormals();
 	}
-	auto result = open3d::pipelines::registration::RegistrationICP(cloudPrev_, *downSampledCloud,
-			params_.scanMatcher_.maxCorrespondenceDistance_, Eigen::Matrix4d::Identity(), *icpObjective_,
-			icpConvergenceCriteria_);
+
+	auto result = open3d::pipelines::registration::RegistrationICP(
+		cloudPrev_, *downSampledCloud, params_.scanMatcher_.maxCorrespondenceDistance_,
+		icpTransform_, *icpObjective_, icpConvergenceCriteria_);
+
+	if (resetIcpTransform_)
+	{
+		icpTransform_ = Eigen::Matrix4d::Identity();
+		resetIcpTransform_ = false;
+	}
 
 	//todo magic
 	const bool isOdomOkay = result.fitness_ > 0.1;
 	if (!isOdomOkay) {
 		  std::cout << "Odometry failed!!!!! \n";
-		  std::cout << "Size of the odom buffer: " << odomToRangeSensorBuffer_.size() << std::endl;
+			std::cout << "Size of the odom buffer: " << odomToRangeSensorBuffer_.size() << std::endl;
 			std::cout << "Scan matching time elapsed: " << timer.elapsedMsec() << " msec \n";
 			std::cout << "Fitness: " << result.fitness_ << "\n";
 			std::cout << "RMSE: " << result.inlier_rmse_ << "\n";
@@ -92,6 +99,12 @@ void LidarOdometry::setParameters(const OdometryParameters &p) {
 //	cropper_ = std::make_shared<CylinderCroppingVolume>(params_.scanProcessing_.croppingRadius_,-3.0,3.0);
 	const auto &par = params_.scanProcessing_.cropper_;
 	cropper_ = croppingVolumeFactory(par);
+}
+
+
+void LidarOdometry::setInitialTransform(Eigen::Matrix4d initial_transform) {
+	icpTransform_ = initial_transform;
+	resetIcpTransform_ = true;
 }
 
 } // namespace o3d_slam

--- a/open3d_slam/src/SlamWrapper.cpp
+++ b/open3d_slam/src/SlamWrapper.cpp
@@ -211,8 +211,8 @@ void SlamWrapper::loadParametersAndInitialize() {
 	}
 }
 
-void SlamWrapper::setInitialMap(PointCloud &initial_map) {
-	TimestampedPointCloud measurement{fromUniversal(0), std::move(initial_map)};
+void SlamWrapper::setInitialMap(const PointCloud &initialMap) {
+	TimestampedPointCloud measurement{fromUniversal(0), std::move(initialMap)};
 
 	const bool isOdomOkay = odometry_->addRangeScan(measurement.cloud_, measurement.time_);
 	if (!isOdomOkay) {
@@ -226,8 +226,8 @@ void SlamWrapper::setInitialMap(PointCloud &initial_map) {
 }
 
 
-void SlamWrapper::setInitialTransform(Eigen::Matrix4d initial_transform) {
-	odometry_->setInitialTransform(initial_transform);
+void SlamWrapper::setInitialTransform(const Eigen::Matrix4d initialTransform) {
+	odometry_->setInitialTransform(initialTransform);
 }
 
 void SlamWrapper::startWorkers() {

--- a/open3d_slam_ros/param/params_velodyne_puck16.yaml
+++ b/open3d_slam_ros/param/params_velodyne_puck16.yaml
@@ -119,8 +119,3 @@ saving_parameters:
   save_at_mission_end: true
   save_map: true
   save_submaps: true
-
-
-  
-
-    

--- a/open3d_slam_ros/src/OnlineRangeDataProcessorRos.cpp
+++ b/open3d_slam_ros/src/OnlineRangeDataProcessorRos.cpp
@@ -24,7 +24,7 @@ void OnlineRangeDataProcessorRos::initialize() {
 	initCommonRosStuff();
 	slam_ = std::make_shared<SlamWrapperRos>(nh_);
 	slam_->loadParametersAndInitialize();
-
+	
 }
 
 void OnlineRangeDataProcessorRos::startProcessing() {


### PR DESCRIPTION
The following changes allow to initialize a pointcloud map and set initial transform for ICP to correctly align first pointcloud scan with a map.
I implemented custom DataRangeProcessorRos for my application that uses an interactive marker (after a bit of refactoring to limit external dependencies I'll try to add it to this package). Using my custom DataRangeProcessorRos process looks as follows:

1. Allign stl model with pointcloud from robot scanner and set transfer and pointcloud in initialization.
![align_stl](https://user-images.githubusercontent.com/22939863/174072099-df64b067-0815-4ea7-b39f-cfa2d9621f54.png)
2. During the first iteration the new scan will align to the initial map and follow the update steps.
![initialized_slam](https://user-images.githubusercontent.com/22939863/174072263-d5aa2eac-7ea1-4648-9ba3-fd0ae4282e95.png)
 