### PR TITLE
Rosp/map init data processor

### DIFF
--- a/open3d_slam_ros/CMakeLists.txt
+++ b/open3d_slam_ros/CMakeLists.txt
@@ -8,6 +8,7 @@ add_compile_options(-O2)
 
 set(SRC_FILES
   src/helpers_ros.cpp
+  src/SlamMapInitializer.cpp
   src/SlamWrapperRos.cpp
   src/OnlineRangeDataProcessorRos.cpp
   src/creators.cpp
@@ -26,6 +27,7 @@ set(CATKIN_PACKAGE_DEPENDENCIES
   tf2_ros
   tf2_geometry_msgs
   rosbag
+  interactive_markers
 )
 
 find_package(Eigen3 REQUIRED)

--- a/open3d_slam_ros/include/open3d_slam_ros/DataProcessorRos.hpp
+++ b/open3d_slam_ros/include/open3d_slam_ros/DataProcessorRos.hpp
@@ -10,6 +10,8 @@
 #include "open3d_slam/time.hpp"
 #include <ros/ros.h>
 
+#include "open3d_slam/SlamWrapper.hpp"
+
 namespace o3d_slam {
 
 class DataProcessorRos {
@@ -23,6 +25,7 @@ public:
 	virtual void processMeasurement(const PointCloud &cloud, const Time &timestamp);
 	void accumulateAndProcessRangeData(const PointCloud &cloud, const Time &timestamp);
 	void initCommonRosStuff();
+	std::shared_ptr<SlamWrapper> getSlamPtr();
 
 
 protected:
@@ -32,6 +35,7 @@ protected:
 	PointCloud accumulatedCloud_;
 	ros::Publisher rawCloudPub_;
 	std::string cloudTopic_;
+	std::shared_ptr<SlamWrapper> slam_;
 	ros::NodeHandlePtr nh_;
 
 };

--- a/open3d_slam_ros/include/open3d_slam_ros/OnlineRangeDataProcessorRos.hpp
+++ b/open3d_slam_ros/include/open3d_slam_ros/OnlineRangeDataProcessorRos.hpp
@@ -26,12 +26,10 @@ public:
 	 void initialize() override;
 	 void startProcessing() override;
 	 void processMeasurement(const PointCloud& cloud, const Time& timestamp) override;
-	 std::shared_ptr<SlamWrapper> getSlamPtr() { return slam_; };
 
 private:
 	 void cloudCallback(const sensor_msgs::PointCloud2ConstPtr &msg);
 
-	std::shared_ptr<SlamWrapper> slam_;
 	ros::Subscriber cloudSubscriber_;
 
 };

--- a/open3d_slam_ros/include/open3d_slam_ros/OnlineRangeDataProcessorRos.hpp
+++ b/open3d_slam_ros/include/open3d_slam_ros/OnlineRangeDataProcessorRos.hpp
@@ -25,7 +25,8 @@ public:
 
 	 void initialize() override;
 	 void startProcessing() override;
-	 void processMeasurement(const PointCloud &cloud, const Time &timestamp) override;
+	 void processMeasurement(const PointCloud& cloud, const Time& timestamp) override;
+	 std::shared_ptr<SlamWrapper> getSlamPtr() { return slam_; };
 
 private:
 	 void cloudCallback(const sensor_msgs::PointCloud2ConstPtr &msg);

--- a/open3d_slam_ros/include/open3d_slam_ros/RosbagRangeDataProcessorRos.hpp
+++ b/open3d_slam_ros/include/open3d_slam_ros/RosbagRangeDataProcessorRos.hpp
@@ -32,7 +32,7 @@ private:
 	 void cloudCallback(const sensor_msgs::PointCloud2ConstPtr &msg);
 	 void readRosbag(const rosbag::Bag &bag);
 
-	std::shared_ptr<SlamWrapper> slam_;
+	// std::shared_ptr<SlamWrapper> slam_;
 	std::string rosbagFilename_;
 };
 

--- a/open3d_slam_ros/include/open3d_slam_ros/SlamMapInitializer.hpp
+++ b/open3d_slam_ros/include/open3d_slam_ros/SlamMapInitializer.hpp
@@ -1,0 +1,50 @@
+/*
+ * OnlineDataProcessorRos.hpp
+ *
+ *  Created on: Apr 21, 2022
+ *      Author: jelavice
+ */
+
+#pragma once
+
+#include <memory>
+#include <atomic>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <nav_msgs/Odometry.h>
+#include "open3d_slam/SlamWrapper.hpp"
+#include <visualization_msgs/InteractiveMarker.h>
+#include <visualization_msgs/InteractiveMarkerFeedback.h>
+#include <interactive_markers/interactive_marker_server.h>
+#include <interactive_markers/menu_handler.h>
+
+namespace o3d_slam {
+
+class SlamMapInitializer{
+
+public:
+	SlamMapInitializer(std::shared_ptr<SlamWrapper> slamPtr, ros::NodeHandlePtr nh);
+	~SlamMapInitializer() = default;
+
+	void initialize();
+
+private:
+	void cloudCallback(const sensor_msgs::PointCloud2ConstPtr &msg);
+	void initInterectiveMarker();
+	void interactiveMarkerCallback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& msg);
+	visualization_msgs::InteractiveMarker createInteractiveMarker() const;
+	
+  interactive_markers::MenuHandler menuHandler_;
+  interactive_markers::InteractiveMarkerServer server_;
+	std::shared_ptr<SlamWrapper> slamPtr_;
+	ros::Subscriber cloudSubscriber_;
+	std::atomic_bool initialized_;
+	std::string frameId_;
+	std::string meshResourcePath_;
+	std::string pcdFilePath_;
+	ros::NodeHandlePtr nh_;
+
+};
+
+} // namespace o3d_slam

--- a/open3d_slam_ros/package.xml
+++ b/open3d_slam_ros/package.xml
@@ -25,6 +25,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>interactive_markers</depend>
   <depend>rosbag</depend>
  
 

--- a/open3d_slam_ros/src/DataProcessorRos.cpp
+++ b/open3d_slam_ros/src/DataProcessorRos.cpp
@@ -29,6 +29,10 @@ namespace o3d_slam {
 	void DataProcessorRos::processMeasurement(const PointCloud &cloud, const Time &timestamp) {
 		std::cout << "Warning you have not implemented processMeasurement!!! \n";
 	}
+	
+	std::shared_ptr<SlamWrapper> DataProcessorRos::getSlamPtr() {
+		return slam_;
+	}
 
 	void DataProcessorRos::accumulateAndProcessRangeData(const PointCloud &cloud, const Time &timestamp) {
 		accumulatedCloud_ += cloud;

--- a/open3d_slam_ros/src/SlamMapInitializer.cpp
+++ b/open3d_slam_ros/src/SlamMapInitializer.cpp
@@ -1,0 +1,161 @@
+/*
+ * SlamMapInitializer.cpp
+ *
+ *  Created on: Jun 16, 2022
+ *      Author: lukaszpi
+ */
+
+#include "open3d_conversions/open3d_conversions.h"
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include "open3d_slam_ros/helpers_ros.hpp"
+#include "open3d_slam/time.hpp"
+#include "open3d_slam/frames.hpp"
+#include "open3d_slam_ros/SlamMapInitializer.hpp"
+#include "open3d_slam_ros/SlamWrapperRos.hpp"
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/Pose.h>
+#include <eigen_conversions/eigen_msg.h>
+
+
+
+namespace o3d_slam {
+
+SlamMapInitializer::SlamMapInitializer(std::shared_ptr<SlamWrapper> slamPtr, ros::NodeHandlePtr nh) :
+  server_("initialization_pose"),
+  slamPtr_(slamPtr),
+  nh_(nh){
+}
+
+void SlamMapInitializer::initialize() {
+  PointCloud raw_map;
+
+  
+	frameId_ = nh_->param<std::string>("map_frame_id", "");
+	meshResourcePath_ = nh_->param<std::string>("map_mesh_path", "");
+	pcdFilePath_ = nh_->param<std::string>("map_pointcloud_path", "");
+
+  initialized_.store(false);
+
+  initInterectiveMarker();
+  
+  if (!open3d::io::ReadPointCloud(pcdFilePath_, raw_map))
+	{
+		std::cerr << "[Error] Initialization pointcloud not loaded" << std::endl;
+  }
+  
+  slamPtr_->setInitialMap(raw_map);
+  
+  while (!initialized_.load())
+  {
+    ros::spinOnce();
+  }
+  
+}
+
+void SlamMapInitializer::cloudCallback(const sensor_msgs::PointCloud2ConstPtr &msg) {
+	open3d::geometry::PointCloud cloud;
+	open3d_conversions::rosToOpen3d(msg, cloud, false);
+  const Time timestamp = fromRos(msg->header.stamp);
+  slamPtr_->addRangeScan(cloud, timestamp);
+}
+
+void SlamMapInitializer::initInterectiveMarker() {
+  menuHandler_.insert("Initialize SLAM", boost::bind(&SlamMapInitializer::interactiveMarkerCallback, this, _1));
+
+  auto interactiveMarker = createInteractiveMarker();
+
+  server_.insert(interactiveMarker);
+  menuHandler_.apply(server_, interactiveMarker.name);
+  server_.applyChanges();
+}
+
+void SlamMapInitializer::interactiveMarkerCallback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& msg) {
+  Eigen::Affine3d init_transform;
+	geometry_msgs::Pose pose = msg->pose;
+	tf::poseMsgToEigen(pose, init_transform);
+	
+  slamPtr_->setInitialTransform(init_transform.matrix());
+  initialized_.store(true);
+}
+
+visualization_msgs::InteractiveMarker SlamMapInitializer::createInteractiveMarker() const {
+	visualization_msgs::InteractiveMarker interactiveMarker;
+  interactiveMarker.header.frame_id = frameId_;
+  interactiveMarker.header.stamp = ros::Time::now();
+  interactiveMarker.name = "Initial Pose";
+  interactiveMarker.scale = 0.5;
+  interactiveMarker.description = "Right click to send command";
+  interactiveMarker.pose.position.x = -1.0;
+  interactiveMarker.pose.position.y = -3.0;
+  interactiveMarker.pose.position.z = -1.0;
+  interactiveMarker.pose.orientation.x = 0.0;
+  interactiveMarker.pose.orientation.y = 0.0;
+  interactiveMarker.pose.orientation.z = 0.0;
+  interactiveMarker.pose.orientation.w = 1.0;
+
+  // create a grey box marker
+  const auto meshMarker = [&meshResourcePath_ = meshResourcePath_]() {
+    visualization_msgs::Marker marker;
+		marker.type = visualization_msgs::Marker::MESH_RESOURCE;
+		marker.mesh_resource = meshResourcePath_;
+    marker.color.r = 0.5;
+    marker.color.g = 0.5;
+    marker.color.b = 0.5;
+    marker.color.a = 0.5;
+    return marker;
+  }();
+
+  // create a non-interactive control which contains the box
+  visualization_msgs::InteractiveMarkerControl boxControl;
+  boxControl.always_visible = 1;
+  boxControl.markers.push_back(meshMarker);
+  boxControl.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_ROTATE_3D;
+
+  // add the control to the interactive marker
+  interactiveMarker.controls.push_back(boxControl);
+
+  // create a control which will move the box
+  // this control does not contain any markers,
+  // which will cause RViz to insert two arrows
+  visualization_msgs::InteractiveMarkerControl control;
+
+  control.orientation.w = 1;
+  control.orientation.x = 1;
+  control.orientation.y = 0;
+  control.orientation.z = 0;
+  control.name = "rotate_x";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  interactiveMarker.controls.push_back(control);
+  control.name = "move_x";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  interactiveMarker.controls.push_back(control);
+
+  control.orientation.w = 1;
+  control.orientation.x = 0;
+  control.orientation.y = 1;
+  control.orientation.z = 0;
+  control.name = "rotate_z";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  interactiveMarker.controls.push_back(control);
+  control.name = "move_z";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  interactiveMarker.controls.push_back(control);
+
+  control.orientation.w = 1;
+  control.orientation.x = 0;
+  control.orientation.y = 0;
+  control.orientation.z = 1;
+  control.name = "rotate_y";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  interactiveMarker.controls.push_back(control);
+  control.name = "move_y";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  interactiveMarker.controls.push_back(control);
+  
+  return interactiveMarker;
+}
+
+
+} // namespace o3d_slam
+

--- a/open3d_slam_ros/src/mapping_node.cpp
+++ b/open3d_slam_ros/src/mapping_node.cpp
@@ -6,6 +6,7 @@
  */
 #include <open3d/Open3D.h>
 #include "open3d_slam_ros/creators.hpp"
+#include "open3d_slam_ros/SlamMapInitializer.hpp"
 
 
 int main(int argc, char **argv) {
@@ -15,11 +16,18 @@ int main(int argc, char **argv) {
 	ros::NodeHandlePtr nh(new ros::NodeHandle("~"));
 
 	const bool isProcessAsFastAsPossible = nh->param<bool>("is_read_from_rosbag", false);
+	const bool initializeMap = nh->param<bool>("initialize_map", false);
 	std::cout << "Is process as fast as possible: " << std::boolalpha << isProcessAsFastAsPossible << "\n";
 
 	std::shared_ptr<DataProcessorRos> dataProcessor = dataProcessorFactory(nh, isProcessAsFastAsPossible);
 
 	dataProcessor->initialize();
+
+	if (initializeMap) {
+		std::shared_ptr<SlamWrapper> slam = dataProcessor->getSlamPtr();
+		std::shared_ptr<SlamMapInitializer> slamMapInitializer = std::make_shared<SlamMapInitializer>(slam, nh);
+		slamMapInitializer->initialize();
+	}
 
 	dataProcessor->startProcessing();
 


### PR DESCRIPTION
It's just a draft PR that proposes a separate Initialization class that can be used in parallel with other DataProcessors to start a map. It still requires a cleanup but if there are suggestions for a different conceptual design I don't want to spend too much time on this.
One comment, I think it would be a clearer composition if we used slamPtr as an initialization value to DataProcessor instead of initializing it in the initialize() method. WDYT? Then the method getSlamPtr() would not be necessary but I don't have that much strong feelings about it.