### PR TITLE
Specify pcd file path for loading map (localization mode)

### DIFF
--- a/open3d_slam_ros/src/mapping_node.cpp
+++ b/open3d_slam_ros/src/mapping_node.cpp
@@ -19,6 +19,7 @@ int main(int argc, char **argv) {
 
 	const std::string paramFolderPath = nh->param<std::string>("parameter_folder_path", "");
 	const std::string paramFilename = nh->param<std::string>("parameter_filename", "");
+	const std::string mapLoadPath = nh->param<std::string>("pcd_file_path", "");
 
 	SlamParameters params;
 	io_lua::loadParameters(paramFolderPath, paramFilename, &params);
@@ -26,7 +27,13 @@ int main(int argc, char **argv) {
 	const bool isProcessAsFastAsPossible = nh->param<bool>("is_read_from_rosbag", false);
 	std::cout << "Is process as fast as possible: " << std::boolalpha << isProcessAsFastAsPossible << "\n";
 	std::cout << "Is use a map for initialization: " << std::boolalpha << params.mapper_.isUseInitialMap_ << "\n";
-
+	if (!mapLoadPath.empty()) {
+		params.mapper_.mapInit_.pcdFilePath_ = mapLoadPath;
+	}
+	if (params.mapper_.isUseInitialMap_) {
+		std::cout << "Loading Map from: " <<  params.mapper_.mapInit_.pcdFilePath_ << "\n";
+	}
+	
 	std::shared_ptr<DataProcessorRos> dataProcessor = dataProcessorFactory(nh, isProcessAsFastAsPossible);
 	dataProcessor->initialize();
 


### PR DESCRIPTION
Hi @nubertj 

I am working as a TA for the Robotics Summer School and was looking into the localization mode of Open3D SLAM. At present, we need to specify the absolute path of the map which needs to be loaded in LUA param file. This is not very convenient and instead, it is easier to pass this as an argument from the launch file.

The arg "pcd_file_path" can now be set in the launch files.

Let me know if you want me to add an example launch file for localization mode

If possible, you can create a new branch on the repo for Robotics Summer School and we can merge the changes to that branch instead of master.

