### PR TITLE
Point master README to ros2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open3D SLAM: A Flexible Pointcloud-based SLAM System for Education
 
+> ROS 2 / Jazzy users: the maintained ROS 2 version lives on the [`ros2`](https://github.com/leggedrobotics/open3d_slam/tree/ros2) branch. This `master` branch documents the older ROS 1 / catkin setup.
+
 open3d_slam is a C++ (cpp) library for SLAM with ROS integration. 
 
 **Main Contact:** Edo Jelavic ([jelavice@ethz.ch](mailto:jelavice@ethz.ch?subject=[GitHub]))


### PR DESCRIPTION
## Summary
- add a short note at the top of the `master` README
- point ROS 2 / Jazzy users to the maintained `ros2` branch

## Why
`master` still documents the older ROS 1 / catkin setup, so this makes the branch split explicit for new users.
